### PR TITLE
Texture view and texture sampling

### DIFF
--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -137,7 +137,7 @@ namespace Ryujinx.Graphics.Metal
             }
 
             var renderCommandEncoder = _commandBuffer.RenderCommandEncoder(descriptor);
-            _renderEncoderState.SetEncoderState(renderCommandEncoder, _vertexDescriptor);
+            _renderEncoderState.SetEncoderState(renderCommandEncoder, descriptor, _vertexDescriptor);
 
             RebindBuffers(renderCommandEncoder);
 
@@ -193,7 +193,7 @@ namespace Ryujinx.Graphics.Metal
                 _helperShaders.BlitShader.VertexFunction,
                 _helperShaders.BlitShader.FragmentFunction,
                 _device);
-            _renderEncoderState.SetEncoderState(renderCommandEncoder, _vertexDescriptor);
+            _renderEncoderState.SetEncoderState(renderCommandEncoder, descriptor, _vertexDescriptor);
 
             var sampler = _device.NewSamplerState(new MTLSamplerDescriptor
             {

--- a/src/Ryujinx.Graphics.Metal/Program.cs
+++ b/src/Ryujinx.Graphics.Metal/Program.cs
@@ -28,6 +28,8 @@ namespace Ryujinx.Graphics.Metal
                 {
                     Logger.Warning?.Print(LogClass.Gpu, $"Shader linking failed: \n{StringHelper.String(libraryError.LocalizedDescription)}");
                     _status = ProgramLinkStatus.Failure;
+                    //Console.WriteLine($"SHADER {index}: {shader.Code}");
+                    //throw new NotImplementedException();
                     return;
                 }
 

--- a/src/Ryujinx.Graphics.Metal/Sampler.cs
+++ b/src/Ryujinx.Graphics.Metal/Sampler.cs
@@ -1,6 +1,7 @@
 using Ryujinx.Graphics.GAL;
 using SharpMetal.Metal;
 using System.Runtime.Versioning;
+using System;
 
 namespace Ryujinx.Graphics.Metal
 {
@@ -23,7 +24,7 @@ namespace Ryujinx.Graphics.Metal
                 LodMinClamp = info.MinLod,
                 LodMaxClamp = info.MaxLod,
                 LodAverage = false,
-                MaxAnisotropy = (uint)info.MaxAnisotropy,
+                MaxAnisotropy = Math.Max((uint)info.MaxAnisotropy, 1),
                 SAddressMode = info.AddressU.Convert(),
                 TAddressMode = info.AddressV.Convert(),
                 RAddressMode = info.AddressP.Convert()

--- a/src/Ryujinx.Graphics.Metal/Texture.cs
+++ b/src/Ryujinx.Graphics.Metal/Texture.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.Graphics.Metal
             var descriptor = new MTLTextureDescriptor
             {
                 PixelFormat = FormatTable.GetFormat(Info.Format),
-                Usage = MTLTextureUsage.ShaderRead,
+                Usage = MTLTextureUsage.Unknown,
                 SampleCount = (ulong)Info.Samples,
                 TextureType = Info.Target.Convert(),
                 Width = (ulong)Info.Width,

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
@@ -133,6 +133,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
                     context.EnterScope();
 
+                    if (context.Definitions.Stage == ShaderStage.Fragment)
+                    {
+                        // TODO: check if it's needed
+                        context.AppendLine("float4 position [[position]];");
+                    }
+
                     foreach (var ioDefinition in inputs.OrderBy(x => x.Location))
                     {
                         string type = GetVarTypeName(context, context.Definitions.GetUserDefinedType(ioDefinition.Location, isOutput: false));

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenHelper.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenHelper.cs
@@ -53,13 +53,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
             Add(Instruction.ConditionalSelect,        InstType.OpTernary,      "?:", 12);
             Add(Instruction.ConvertFP32ToFP64,        0); // MSL does not have a 64-bit FP
             Add(Instruction.ConvertFP64ToFP32,        0); // MSL does not have a 64-bit FP
-            Add(Instruction.ConvertFP32ToS32,         InstType.Cast,           "int");
-            Add(Instruction.ConvertFP32ToU32,         InstType.Cast,           "uint");
+            Add(Instruction.ConvertFP32ToS32,         InstType.CallUnary,      "int");
+            Add(Instruction.ConvertFP32ToU32,         InstType.CallUnary,      "uint");
             Add(Instruction.ConvertFP64ToS32,         0); // MSL does not have a 64-bit FP
             Add(Instruction.ConvertFP64ToU32,         0); // MSL does not have a 64-bit FP
-            Add(Instruction.ConvertS32ToFP32,         InstType.Cast,           "float");
+            Add(Instruction.ConvertS32ToFP32,         InstType.CallUnary,      "float");
             Add(Instruction.ConvertS32ToFP64,         0); // MSL does not have a 64-bit FP
-            Add(Instruction.ConvertU32ToFP32,         InstType.Cast,           "float");
+            Add(Instruction.ConvertU32ToFP32,         InstType.CallUnary,      "float");
             Add(Instruction.ConvertU32ToFP64,         0); // MSL does not have a 64-bit FP
             Add(Instruction.Cosine,                   InstType.CallUnary,      "cos");
             Add(Instruction.Ddx,                      InstType.CallUnary,      "dfdx");

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
@@ -158,7 +158,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
 
             bool colorIsVector = isGather || !isShadow;
 
-            string texCall = "texture.";
+            string samplerName = GetSamplerName(context.Properties, texOp);
+            string texCall = $"tex_{samplerName}";
+            texCall += ".";
 
             int srcIndex = 0;
 
@@ -175,9 +177,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
             {
                 texCall += "sample(";
 
-                string samplerName = GetSamplerName(context.Properties, texOp);
-
-                texCall += samplerName;
+                texCall += $"samp_{samplerName}";
             }
 
             int coordsCount = texOp.Type.GetDimensions();

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstType.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstType.cs
@@ -29,7 +29,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
         Call = 1 << 10,
         Atomic = 1 << 11,
         Special = 1 << 12,
-        Cast = 1 << 13,
 
         ArityMask = 0xff,
     }

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/IoMap.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/IoMap.cs
@@ -30,6 +30,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
                 IoVariable.UserDefined => GetUserDefinedVariableName(definitions, location, component, isOutput, isPerPatch),
                 IoVariable.VertexId => ("vertex_id", AggregateType.S32),
                 IoVariable.ViewportIndex => ("viewport_array_index", AggregateType.S32),
+                IoVariable.FragmentCoord => ("in.position", AggregateType.Vector4 | AggregateType.FP32),
                 _ => (null, AggregateType.Invalid),
             };
         }

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -122,6 +122,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                 {
                     args = args.Append($"device float4 *{storageBuffers.Name} [[buffer({storageBuffers.Binding})]]").ToArray();
                 }
+
+                foreach (var texture in context.Properties.Textures.Values)
+                {
+                    // TODO: don't use always texture2d
+                    args = args.Append($"texture2d<float> tex_{texture.Name} [[texture({texture.Binding})]]").ToArray();
+                    args = args.Append($"sampler samp_{texture.Name} [[sampler({texture.Binding})]]").ToArray();
+                }
             }
 
             return $"{funcKeyword} {returnType} {funcName ?? function.Name}({string.Join(", ", args)})";


### PR DESCRIPTION
This PR enables the creation of texture view. Textures and samplers are passed as arguments to the shader. Fragment shaders can get the coordinate by using in.position. These changes make SMO to not crash, and while the output is just a black or grey screen, inspecting with Metal Frame Capture shows this texture as 1 of the color attachments:
![smo_ryu_first_render](https://github.com/IsaacMarovitz/Ryujinx/assets/96914946/664be991-cf8f-4570-a622-4a6059ea915f)

Also, sorry if the code isn't the best, since I am not a c# developer.

Edit: The reason for the wrong colors in the image is probably incorrect swizzling of the texture view, but I can't debug it now, because my frame capture decided to stop working.