### PR TITLE
Shader fixes

### DIFF
--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -600,11 +600,12 @@ namespace Ryujinx.Graphics.Metal
             {
                 if (buffer.Range.Size != 0)
                 {
+                    // Offset the binding by 15
                     _storageBuffers.Add(new BufferInfo
                     {
                         Handle = buffer.Range.Handle.ToIntPtr(),
                         Offset = buffer.Range.Offset,
-                        Index = buffer.Binding
+                        Index = buffer.Binding + 15
                     });
                 }
             }

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/DefaultNames.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/DefaultNames.cs
@@ -10,6 +10,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
         public const string ArgumentNamePrefix = "a";
 
-        public const string UndefinedName = "undef";
+        public const string UndefinedName = "0";
     }
 }

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenHelper.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenHelper.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
             Add(Instruction.AtomicOr,                 InstType.AtomicBinary,   "atomic_or_explicit");
             Add(Instruction.AtomicSwap,               InstType.AtomicBinary,   "atomic_exchange_explicit");
             Add(Instruction.AtomicXor,                InstType.AtomicBinary,   "atomic_xor_explicit");
-            Add(Instruction.Absolute,                 InstType.AtomicBinary,   "atomic_abs_explicit");
+            Add(Instruction.Absolute,                 InstType.CallUnary,      "abs");
             Add(Instruction.Add,                      InstType.OpBinaryCom,    "+",  2);
             Add(Instruction.Ballot,                   InstType.CallUnary,      "simd_ballot");
             Add(Instruction.Barrier,                  InstType.Special);

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
@@ -184,13 +184,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
 
             int pCount = coordsCount;
 
-            int arrayIndexElem = -1;
-
-            if (isArray)
-            {
-                arrayIndexElem = pCount++;
-            }
-
             if (isShadow && !isGather)
             {
                 pCount++;
@@ -211,19 +204,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
 
                     for (int index = 0; index < count; index++)
                     {
-                        if (arrayIndexElem == index)
-                        {
-                            elems[index] = Src(AggregateType.S32);
-
-                            if (!intCoords)
-                            {
-                                elems[index] = "float(" + elems[index] + ")";
-                            }
-                        }
-                        else
-                        {
-                            elems[index] = Src(coordType);
-                        }
+                        elems[index] = Src(coordType);
                     }
 
                     string prefix = intCoords ? "int" : "float";
@@ -237,6 +218,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
             }
 
             Append(AssemblePVector(pCount));
+
+            if (isArray)
+            {
+                texCall += ", " + Src(AggregateType.S32);
+            }
 
             texCall += ")" + (colorIsVector ? GetMaskMultiDest(texOp.Index) : "");
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -130,7 +130,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                 {
                     var varType = storageBuffers.Type.Fields[0].Type & ~AggregateType.Array;
                     // Offset the binding by 15 to avoid clashing with the constant buffers
-                    args = args.Append($"device {Declarations.GetVarTypeName(context, varType)} *{storageBuffers.Name} [[buffer({15 + storageBuffers.Binding})]]").ToArray();
+                    args = args.Append($"device {Declarations.GetVarTypeName(context, varType)} *{storageBuffers.Name} [[buffer({storageBuffers.Binding + 15})]]").ToArray();
                 }
 
                 foreach (var texture in context.Properties.Textures.Values)

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -115,12 +115,14 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
                 foreach (var constantBuffer in context.Properties.ConstantBuffers.Values)
                 {
-                    args = args.Append($"constant float4 *{constantBuffer.Name} [[buffer({constantBuffer.Binding})]]").ToArray();
+                    var varType = constantBuffer.Type.Fields[0].Type & ~AggregateType.Array;
+                    args = args.Append($"constant {Declarations.GetVarTypeName(context, varType)} *{constantBuffer.Name} [[buffer({constantBuffer.Binding})]]").ToArray();
                 }
 
                 foreach (var storageBuffers in context.Properties.StorageBuffers.Values)
                 {
-                    args = args.Append($"device float4 *{storageBuffers.Name} [[buffer({storageBuffers.Binding})]]").ToArray();
+                    var varType = storageBuffers.Type.Fields[0].Type & ~AggregateType.Array;
+                    args = args.Append($"device {Declarations.GetVarTypeName(context, varType)} *{storageBuffers.Name} [[buffer({storageBuffers.Binding})]]").ToArray();
                 }
 
                 foreach (var texture in context.Properties.Textures.Values)

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -137,7 +137,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                 {
                     var textureTypeName = texture.Type.ToMslTextureType();
                     args = args.Append($"{textureTypeName} tex_{texture.Name} [[texture({texture.Binding})]]").ToArray();
-                    args = args.Append($"sampler samp_{texture.Name} [[sampler({texture.Binding})]]").ToArray();
+                    // If the texture is not separate, we need to declare a sampler
+                    if (!texture.Separate)
+                    {
+                        args = args.Append($"sampler samp_{texture.Name} [[sampler({texture.Binding})]]").ToArray();
+                    }
                 }
             }
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -129,7 +129,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                 foreach (var storageBuffers in context.Properties.StorageBuffers.Values)
                 {
                     var varType = storageBuffers.Type.Fields[0].Type & ~AggregateType.Array;
-                    args = args.Append($"device {Declarations.GetVarTypeName(context, varType)} *{storageBuffers.Name} [[buffer({storageBuffers.Binding})]]").ToArray();
+                    // Offset the binding by 15 to avoid clashing with the constant buffers
+                    args = args.Append($"device {Declarations.GetVarTypeName(context, varType)} *{storageBuffers.Name} [[buffer({15 + storageBuffers.Binding})]]").ToArray();
                 }
 
                 foreach (var texture in context.Properties.Textures.Values)

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -113,6 +113,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                     }
                 }
 
+                // TODO: add these only if they are used
+                if (stage == ShaderStage.Vertex)
+                {
+                    args = args.Append("uint vertex_id [[vertex_id]]").ToArray();
+                    args = args.Append("uint instance_id [[instance_id]]").ToArray();
+                }
+
                 foreach (var constantBuffer in context.Properties.ConstantBuffers.Values)
                 {
                     var varType = constantBuffer.Type.Fields[0].Type & ~AggregateType.Array;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/MslGenerator.cs
@@ -135,8 +135,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
                 foreach (var texture in context.Properties.Textures.Values)
                 {
-                    // TODO: don't use always texture2d
-                    args = args.Append($"texture2d<float> tex_{texture.Name} [[texture({texture.Binding})]]").ToArray();
+                    var textureTypeName = texture.Type.ToMslTextureType();
+                    args = args.Append($"{textureTypeName} tex_{texture.Name} [[texture({texture.Binding})]]").ToArray();
                     args = args.Append($"sampler samp_{texture.Name} [[sampler({texture.Binding})]]").ToArray();
                 }
             }

--- a/src/Ryujinx.Graphics.Shader/SamplerType.cs
+++ b/src/Ryujinx.Graphics.Shader/SamplerType.cs
@@ -155,5 +155,31 @@ namespace Ryujinx.Graphics.Shader
 
             return typeName;
         }
+
+        public static string ToMslTextureType(this SamplerType type)
+        {
+            string typeName = (type & SamplerType.Mask) switch
+            {
+                SamplerType.None => "texture",
+                SamplerType.Texture1D => "texture1d",
+                SamplerType.TextureBuffer => "texturebuffer",
+                SamplerType.Texture2D => "texture2d",
+                SamplerType.Texture3D => "texture3d",
+                SamplerType.TextureCube => "texturecube",
+                _ => throw new ArgumentException($"Invalid sampler type \"{type}\"."),
+            };
+
+            if ((type & SamplerType.Multisample) != 0)
+            {
+                typeName += "_ms";
+            }
+
+            if ((type & SamplerType.Array) != 0)
+            {
+                typeName += "_array";
+            }
+
+            return typeName + "<float>";
+        }
     }
 }


### PR DESCRIPTION
This PR fixes some issues with shaders:
1. when sampling from texture arrays, the array index is passed as an additional argument, not as part of the coordinates
2. 0 is used instead of 'undef'
3. 'abs' is used instead of 'atomic_abs_explicit'
4. vertex and instance id is passed as an argument to the vertex shader
5. texture type is not hardcoded to 'texture2d'
6. constant and storage buffer use pointer to the first type in the structure as their type instead of 'float4*'
7. storage buffers binding is offset by 15, so bindings of [0...14] are used for constant buffers, while [15...30] for storage buffers (I am sure there are better solutions to handle this, but this could work as a temporary solution)

With these fixes, all shaders in SMO compile without errors.