### PR TITLE
Don't end render pass unless necessary

### DIFF
--- a/src/Ryujinx.Graphics.Metal/EncoderState.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderState.cs
@@ -16,6 +16,12 @@ namespace Ryujinx.Graphics.Metal
             Pipeline = true;
             DepthStencil = true;
         }
+
+        public void Clear()
+        {
+            Pipeline = false;
+            DepthStencil = false;
+        }
     }
 
     [SupportedOSPlatform("macos")]

--- a/src/Ryujinx.Graphics.Metal/EncoderState.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderState.cs
@@ -5,6 +5,19 @@ using System.Runtime.Versioning;
 
 namespace Ryujinx.Graphics.Metal
 {
+    // TODO: use this (unused right now)
+    public struct DirtyFlags
+    {
+        public bool Pipeline = false;
+        public bool DepthStencil = false;
+        public bool CullMode = false;
+        public bool Winding = false;
+        public bool Viewport = false;
+        public bool Scissor = false;
+
+        public DirtyFlags() { }
+    }
+
     [SupportedOSPlatform("macos")]
     public struct EncoderState
     {
@@ -51,6 +64,9 @@ namespace Ryujinx.Graphics.Metal
 
         public VertexBufferDescriptor[] VertexBuffers = [];
         public VertexAttribDescriptor[] VertexAttribs = [];
+
+        // Dirty flags
+        public DirtyFlags Dirty = new();
 
         public EncoderState() { }
     }

--- a/src/Ryujinx.Graphics.Metal/EncoderState.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderState.cs
@@ -5,7 +5,6 @@ using System.Runtime.Versioning;
 
 namespace Ryujinx.Graphics.Metal
 {
-    // TODO: use this (unused right now)
     public struct DirtyFlags
     {
         public bool Pipeline = false;

--- a/src/Ryujinx.Graphics.Metal/EncoderState.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderState.cs
@@ -16,6 +16,15 @@ namespace Ryujinx.Graphics.Metal
         public bool Scissor = false;
 
         public DirtyFlags() { }
+
+        public void MarkAll() {
+            Pipeline = true;
+            DepthStencil = true;
+            CullMode = true;
+            Winding = true;
+            Viewport = true;
+            Scissor = true;
+        }
     }
 
     [SupportedOSPlatform("macos")]

--- a/src/Ryujinx.Graphics.Metal/EncoderState.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderState.cs
@@ -10,20 +10,12 @@ namespace Ryujinx.Graphics.Metal
     {
         public bool Pipeline = false;
         public bool DepthStencil = false;
-        public bool CullMode = false;
-        public bool Winding = false;
-        public bool Viewport = false;
-        public bool Scissor = false;
 
         public DirtyFlags() { }
 
         public void MarkAll() {
             Pipeline = true;
             DepthStencil = true;
-            CullMode = true;
-            Winding = true;
-            Viewport = true;
-            Scissor = true;
         }
     }
 

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -464,7 +464,7 @@ namespace Ryujinx.Graphics.Metal
                 }
             }
 
-            // Inline Update
+            // Inline update
             if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
             {
                 var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
@@ -491,7 +491,7 @@ namespace Ryujinx.Graphics.Metal
                 }
             }
 
-            // Inline Update
+            // Inline update
             if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
             {
                 var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
@@ -504,7 +504,7 @@ namespace Ryujinx.Graphics.Metal
         {
             _currentState.CullMode = enable ? face.Convert() : MTLCullMode.None;
 
-            // Inline Update
+            // Inline update
             if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
             {
                 var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
@@ -517,7 +517,7 @@ namespace Ryujinx.Graphics.Metal
         {
             _currentState.Winding = frontFace.Convert();
 
-            // Inline Update
+            // Inline update
             if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
             {
                 var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -565,12 +565,15 @@ namespace Ryujinx.Graphics.Metal
 
             for (int i = 0; i < bufferDescriptors.Length; i++)
             {
-                buffers.Add(new BufferInfo
+                if (bufferDescriptors[i].Buffer.Handle.ToIntPtr() != IntPtr.Zero)
                 {
-                    Handle = bufferDescriptors[i].Buffer.Handle.ToIntPtr(),
-                    Offset = bufferDescriptors[i].Buffer.Offset,
-                    Index = i
-                });
+                    buffers.Add(new BufferInfo
+                    {
+                        Handle = bufferDescriptors[i].Buffer.Handle.ToIntPtr(),
+                        Offset = bufferDescriptors[i].Buffer.Offset,
+                        Index = i
+                    });
+                }
             }
 
             SetBuffers(renderCommandEncoder, buffers);

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -105,6 +105,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void RebindState(MTLRenderCommandEncoder renderCommandEncoder)
         {
+            // TODO: only rebind the dirty state
             SetPipelineState(renderCommandEncoder);
             SetDepthStencilState(renderCommandEncoder, _currentState.DepthStencilState);
             SetDepthClamp(renderCommandEncoder, _currentState.DepthClipMode);

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -48,15 +48,16 @@ namespace Ryujinx.Graphics.Metal
 
         public MTLRenderCommandEncoder GetOrCreateRenderEncoder()
         {
-            if (_currentEncoder != null)
+            if (_currentEncoder == null || _currentEncoderType != EncoderType.Render)
             {
-                if (_currentEncoderType == EncoderType.Render)
-                {
-                    return new MTLRenderCommandEncoder(_currentEncoder.Value);
-                }
+                BeginRenderPass();
             }
 
-            return BeginRenderPass();
+            var renderCommandEncoder = new MTLRenderCommandEncoder(_currentEncoder.Value);
+
+            _encoderStateManager.RebindState(renderCommandEncoder);
+
+            return renderCommandEncoder;
         }
 
         public MTLBlitCommandEncoder GetOrCreateBlitEncoder()

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -48,12 +48,16 @@ namespace Ryujinx.Graphics.Metal
 
         public MTLRenderCommandEncoder GetOrCreateRenderEncoder()
         {
+            MTLRenderCommandEncoder renderCommandEncoder;
+
             if (_currentEncoder == null || _currentEncoderType != EncoderType.Render)
             {
-                BeginRenderPass();
+                renderCommandEncoder = BeginRenderPass();
             }
-
-            var renderCommandEncoder = new MTLRenderCommandEncoder(_currentEncoder.Value);
+            else
+            {
+                renderCommandEncoder = new MTLRenderCommandEncoder(_currentEncoder.Value);
+            }
 
             _encoderStateManager.RebindState(renderCommandEncoder);
 


### PR DESCRIPTION
Right now the render pass is ended on every program and blend state change, which is really unnecessary. My idea is to instead mark the state dirty and on every GetOrCreateRenderEncoder, the dirty state is rebound/recreated. Currently, the dirty state isn't tracked, so all the state is rebound every time an encoder is requested. I hope we don't get into the same situation as yesterday lol.