### PR TITLE
More shader fixes

### DIFF
--- a/src/Ryujinx.Graphics.Metal/MetalRenderer.cs
+++ b/src/Ryujinx.Graphics.Metal/MetalRenderer.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void BackgroundContextAction(Action action, bool alwaysBackground = false)
         {
-            throw new NotImplementedException();
+            Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
         }
 
         public BufferHandle CreateBuffer(int size, BufferAccess access, BufferHandle storageHint)

--- a/src/Ryujinx.Graphics.Metal/Program.cs
+++ b/src/Ryujinx.Graphics.Metal/Program.cs
@@ -28,8 +28,6 @@ namespace Ryujinx.Graphics.Metal
                 {
                     Logger.Warning?.Print(LogClass.Gpu, $"Shader linking failed: \n{StringHelper.String(libraryError.LocalizedDescription)}");
                     _status = ProgramLinkStatus.Failure;
-                    Console.WriteLine(shader.Code);
-                    throw new NotImplementedException();
                     return;
                 }
 

--- a/src/Ryujinx.Graphics.Metal/Program.cs
+++ b/src/Ryujinx.Graphics.Metal/Program.cs
@@ -28,6 +28,8 @@ namespace Ryujinx.Graphics.Metal
                 {
                     Logger.Warning?.Print(LogClass.Gpu, $"Shader linking failed: \n{StringHelper.String(libraryError.LocalizedDescription)}");
                     _status = ProgramLinkStatus.Failure;
+                    Console.WriteLine(shader.Code);
+                    throw new NotImplementedException();
                     return;
                 }
 

--- a/src/Ryujinx.Graphics.Metal/Texture.cs
+++ b/src/Ryujinx.Graphics.Metal/Texture.cs
@@ -68,11 +68,7 @@ namespace Ryujinx.Graphics.Metal
             slices.location = (ulong)firstLayer;
             slices.length = 1;
 
-            if (info.Target == Target.Texture3D)
-            {
-                slices.length = (ulong)Info.Depth;
-            }
-            else if (info.Target != Target.Cubemap)
+            if (info.Target != Target.Texture3D && info.Target != Target.Cubemap)
             {
                 slices.length = (ulong)Info.Depth;
             }

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
@@ -149,7 +149,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                         context.AppendLine("float4 position [[position]];");
                     }
 
-
                     foreach (var ioDefinition in inputs.OrderBy(x => x.Location))
                     {
                         string type = ioDefinition.IoVariable switch

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
@@ -143,11 +143,18 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
                     context.EnterScope();
 
+                    if (context.Definitions.Stage == ShaderStage.Fragment)
+                    {
+                        // TODO: check if it's needed
+                        context.AppendLine("float4 position [[position]];");
+                    }
+
+
                     foreach (var ioDefinition in inputs.OrderBy(x => x.Location))
                     {
                         string type = ioDefinition.IoVariable switch
                         {
-                            IoVariable.Position => "float4",
+                            // IoVariable.Position => "float4",
                             IoVariable.GlobalId => "uint3",
                             IoVariable.VertexId => "uint",
                             IoVariable.VertexIndex => "uint",
@@ -155,7 +162,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                         };
                         string name = ioDefinition.IoVariable switch
                         {
-                            IoVariable.Position => "position",
+                            // IoVariable.Position => "position",
                             IoVariable.GlobalId => "global_id",
                             IoVariable.VertexId => "vertex_id",
                             IoVariable.VertexIndex => "vertex_index",
@@ -163,7 +170,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                         };
                         string suffix = ioDefinition.IoVariable switch
                         {
-                            IoVariable.Position => "[[position]]",
+                            // IoVariable.Position => "[[position]]",
                             IoVariable.GlobalId => "[[thread_position_in_grid]]",
                             IoVariable.VertexId => "[[vertex_id]]",
                             // TODO: Avoid potential redeclaration

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
@@ -143,24 +143,36 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
                     context.EnterScope();
 
-                    if (context.Definitions.Stage == ShaderStage.Fragment)
-                    {
-                        // TODO: check if it's needed
-                        context.AppendLine("float4 position [[position]];");
-                    }
-
                     foreach (var ioDefinition in inputs.OrderBy(x => x.Location))
                     {
-                        string type = GetVarTypeName(context, context.Definitions.GetUserDefinedType(ioDefinition.Location, isOutput: false));
-                        string name = $"{DefaultNames.IAttributePrefix}{ioDefinition.Location}";
-                        string suffix = context.Definitions.Stage switch
+                        string type = ioDefinition.IoVariable switch
                         {
-                            ShaderStage.Vertex => $" [[attribute({ioDefinition.Location})]]",
-                            ShaderStage.Fragment => $" [[user(loc{ioDefinition.Location})]]",
+                            IoVariable.Position => "float4",
+                            IoVariable.GlobalId => "uint3",
+                            IoVariable.VertexId => "uint",
+                            IoVariable.VertexIndex => "uint",
+                            _ => GetVarTypeName(context, context.Definitions.GetUserDefinedType(ioDefinition.Location, isOutput: false))
+                        };
+                        string name = ioDefinition.IoVariable switch
+                        {
+                            IoVariable.Position => "position",
+                            IoVariable.GlobalId => "global_id",
+                            IoVariable.VertexId => "vertex_id",
+                            IoVariable.VertexIndex => "vertex_index",
+                            _ => $"{DefaultNames.IAttributePrefix}{ioDefinition.Location}"
+                        };
+                        string suffix = ioDefinition.IoVariable switch
+                        {
+                            IoVariable.Position => "[[position]]",
+                            IoVariable.GlobalId => "[[thread_position_in_grid]]",
+                            IoVariable.VertexId => "[[vertex_id]]",
+                            // TODO: Avoid potential redeclaration
+                            IoVariable.VertexIndex => "[[vertex_id]]",
+                            IoVariable.UserDefined => context.Definitions.Stage == ShaderStage.Fragment ? $"[[user(loc{ioDefinition.Location})]]" : $"[[attribute({ioDefinition.Location})]]",
                             _ => ""
                         };
 
-                        context.AppendLine($"{type} {name}{suffix};");
+                        context.AppendLine($"{type} {name} {suffix};");
                     }
 
                     context.LeaveScope(";");
@@ -212,14 +224,14 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                         };
                         string suffix = ioDefinition.IoVariable switch
                         {
-                            IoVariable.Position => " [[position]]",
-                            IoVariable.PointSize => " [[point_size]]",
-                            IoVariable.UserDefined => $" [[user(loc{ioDefinition.Location})]]",
-                            IoVariable.FragmentOutputColor => $" [[color({ioDefinition.Location})]]",
+                            IoVariable.Position => "[[position]]",
+                            IoVariable.PointSize => "[[point_size]]",
+                            IoVariable.UserDefined => $"[[user(loc{ioDefinition.Location})]]",
+                            IoVariable.FragmentOutputColor => $"[[color({ioDefinition.Location})]]",
                             _ => ""
                         };
 
-                        context.AppendLine($"{type} {name}{suffix};");
+                        context.AppendLine($"{type} {name} {suffix};");
                     }
 
                     context.LeaveScope(";");

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
@@ -197,7 +197,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                         {
                             IoVariable.Position => "position",
                             IoVariable.PointSize => "point_size",
-                            IoVariable.FragmentOutputColor => "color",
+                            IoVariable.FragmentOutputColor => $"color{ioDefinition.Location}",
                             _ => $"{DefaultNames.OAttributePrefix}{ioDefinition.Location}"
                         };
                         string suffix = ioDefinition.IoVariable switch

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Declarations.cs
@@ -63,6 +63,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
 
         public static void DeclareLocals(CodeGenContext context, StructuredFunction function, ShaderStage stage)
         {
+            DeclareMemories(context, context.Properties.LocalMemories.Values, isShared: false);
             switch (stage)
             {
                 case ShaderStage.Vertex:
@@ -104,6 +105,15 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl
                 AggregateType.Vector4 | AggregateType.U32 => "uint4",
                 _ => throw new ArgumentException($"Invalid variable type \"{type}\"."),
             };
+        }
+
+        private static void DeclareMemories(CodeGenContext context, IEnumerable<MemoryDefinition> memories, bool isShared)
+        {
+            foreach (var memory in memories)
+            {
+                var typeName = GetVarTypeName(context, memory.Type & ~AggregateType.Array);
+                context.AppendLine($"{typeName} {memory.Name}[{memory.ArrayLength}];");
+            }
         }
 
         private static void DeclareInputAttributes(CodeGenContext context, IEnumerable<IoDefinition> inputs)

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
@@ -316,7 +316,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
                     texCall += $"{lodExpr}";
                 }
 
-                texCall += $"){GetMask(texOp.Index)}";
+                texCall += $")";
             }
 
             return texCall;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
@@ -175,19 +175,24 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
             }
             else
             {
-                texCall += "sample(";
+                texCall += "sample";
 
-                texCall += $"samp_{samplerName}";
+                if (isGather)
+                {
+                    texCall += "_gather";
+                }
+
+                if (isShadow)
+                {
+                    texCall += "_compare";
+                }
+
+                texCall += $"(samp_{samplerName}";
             }
 
             int coordsCount = texOp.Type.GetDimensions();
 
             int pCount = coordsCount;
-
-            if (isShadow && !isGather)
-            {
-                pCount++;
-            }
 
             void Append(string str)
             {
@@ -223,6 +228,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
             {
                 texCall += ", " + Src(AggregateType.S32);
             }
+
+            if (isShadow)
+            {
+                texCall += ", " + Src(AggregateType.S32);
+            }
+
+            // TODO: Support offsets
 
             texCall += ")" + (colorIsVector ? GetMaskMultiDest(texOp.Index) : "");
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/InstGenMemory.cs
@@ -267,7 +267,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
                 return NumberFormatter.FormatInt(0);
             }
 
-            string textureName = "texture";
+            string samplerName = GetSamplerName(context.Properties, texOp);
+            string textureName = $"tex_{samplerName}";
             string texCall = textureName + ".";
             texCall += $"get_num_samples()";
 
@@ -278,7 +279,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
         {
             AstTextureOperation texOp = (AstTextureOperation)operation;
 
-            string textureName = "texture";
+            string samplerName = GetSamplerName(context.Properties, texOp);
+            string textureName = $"tex_{samplerName}";
             string texCall = textureName + ".";
 
             if (texOp.Index == 3)

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/IoMap.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/IoMap.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
                 // gl_VertexIndex does not have a direct equivalent in MSL
                 IoVariable.VertexIndex => ("vertex_index", AggregateType.U32),
                 IoVariable.ViewportIndex => ("viewport_array_index", AggregateType.S32),
-                IoVariable.FragmentCoord => ("position", AggregateType.Vector4 | AggregateType.FP32),
+                IoVariable.FragmentCoord => ("in.position", AggregateType.Vector4 | AggregateType.FP32),
                 _ => (null, AggregateType.Invalid),
             };
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/IoMap.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Msl/Instructions/IoMap.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Msl.Instructions
                 IoVariable.BaseInstance => ("base_instance", AggregateType.S32),
                 IoVariable.BaseVertex => ("base_vertex", AggregateType.S32),
                 IoVariable.ClipDistance => ("clip_distance", AggregateType.Array | AggregateType.FP32),
-                IoVariable.FragmentOutputColor => ("out.color", AggregateType.Vector4 | AggregateType.FP32),
+                IoVariable.FragmentOutputColor => ($"out.color{location}", AggregateType.Vector4 | AggregateType.FP32),
                 IoVariable.FragmentOutputDepth => ("depth", AggregateType.FP32),
                 IoVariable.FrontFacing => ("front_facing", AggregateType.Bool),
                 IoVariable.InstanceId => ("instance_id", AggregateType.S32),

--- a/src/Ryujinx.Graphics.Shader/SamplerType.cs
+++ b/src/Ryujinx.Graphics.Shader/SamplerType.cs
@@ -158,16 +158,29 @@ namespace Ryujinx.Graphics.Shader
 
         public static string ToMslTextureType(this SamplerType type)
         {
-            string typeName = (type & SamplerType.Mask) switch
+            string typeName;
+
+            if ((type & SamplerType.Shadow) != 0)
             {
-                SamplerType.None => "texture",
-                SamplerType.Texture1D => "texture1d",
-                SamplerType.TextureBuffer => "texturebuffer",
-                SamplerType.Texture2D => "texture2d",
-                SamplerType.Texture3D => "texture3d",
-                SamplerType.TextureCube => "texturecube",
-                _ => throw new ArgumentException($"Invalid sampler type \"{type}\"."),
-            };
+                typeName = (type & SamplerType.Mask) switch
+                {
+                    SamplerType.Texture2D => "depth2d",
+                    SamplerType.TextureCube => "depthcube",
+                    _ => throw new ArgumentException($"Invalid shadow texture type \"{type}\"."),
+                };
+            }
+            else
+            {
+                typeName = (type & SamplerType.Mask) switch
+                {
+                    SamplerType.Texture1D => "texture1d",
+                    SamplerType.TextureBuffer => "texturebuffer",
+                    SamplerType.Texture2D => "texture2d",
+                    SamplerType.Texture3D => "texture3d",
+                    SamplerType.TextureCube => "texturecube",
+                    _ => throw new ArgumentException($"Invalid texture type \"{type}\"."),
+                };
+            }
 
             if ((type & SamplerType.Multisample) != 0)
             {


### PR DESCRIPTION
Supports writing to multiple render targets in the shader. Fix incorrect name for textures when calling certain samples (like `get_width`). `local_memory` is now declared as an array of `uints`. There was a texture size error which is now fixed. It used the `Index` to index into the size, but the size was just a scalar (for example, getting height of a texture looked like this: `tex.get_height().g`).