### PR TITLE
Better clear system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,11 +38,7 @@
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.30.0-build32" />
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
-<<<<<<< HEAD
     <PackageVersion Include="SharpMetal" Version="1.0.0-preview14" />
-=======
-    <PackageVersion Include="SharpMetal" Version="1.0.0-preview12" />
->>>>>>> 3eab14be7 (Set scissors & viewports)
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,11 @@
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.30.0-build32" />
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
+<<<<<<< HEAD
     <PackageVersion Include="SharpMetal" Version="1.0.0-preview14" />
+=======
+    <PackageVersion Include="SharpMetal" Version="1.0.0-preview12" />
+>>>>>>> 3eab14be7 (Set scissors & viewports)
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -45,6 +45,17 @@ namespace Ryujinx.Graphics.Metal
             {
                 _currentState = _backStates[_backStates.Count - 1];
                 _backStates.RemoveAt(_backStates.Count - 1);
+
+                // Set all the inline state, since it might have changed
+                var renderCommandEncoder = _pipeline.GetOrCreateRenderEncoder();
+                SetDepthClamp(renderCommandEncoder);
+                SetScissors(renderCommandEncoder);
+                SetViewports(renderCommandEncoder);
+                SetVertexBuffers(renderCommandEncoder, _currentState.VertexBuffers);
+                SetBuffers(renderCommandEncoder, _currentState.UniformBuffers, true);
+                SetBuffers(renderCommandEncoder, _currentState.StorageBuffers, true);
+                SetCullMode(renderCommandEncoder);
+                SetFrontFace(renderCommandEncoder);
             } else
             {
                 Logger.Error?.Print(LogClass.Gpu, "No state to restore");

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -36,6 +36,10 @@ namespace Ryujinx.Graphics.Metal
 
         public void Dispose()
         {
+            // State
+            _currentState.FrontFaceStencil.Dispose();
+            _currentState.BackFaceStencil.Dispose();
+
             _renderPipelineCache.Dispose();
             _depthStencilCache.Dispose();
         }
@@ -327,18 +331,11 @@ namespace Ryujinx.Graphics.Metal
         // Inlineable
         public void UpdateStencilState(StencilTestDescriptor stencilTest)
         {
-            var backFace = new MTLStencilDescriptor
-            {
-                StencilFailureOperation = stencilTest.BackSFail.Convert(),
-                DepthFailureOperation = stencilTest.BackDpFail.Convert(),
-                DepthStencilPassOperation = stencilTest.BackDpPass.Convert(),
-                StencilCompareFunction = stencilTest.BackFunc.Convert(),
-                ReadMask = (uint)stencilTest.BackFuncMask,
-                WriteMask = (uint)stencilTest.BackMask
-            };
-            _currentState.BackFaceStencil = backFace;
+            // Cleanup old state
+            _currentState.FrontFaceStencil.Dispose();
+            _currentState.BackFaceStencil.Dispose();
 
-            var frontFace = new MTLStencilDescriptor
+            _currentState.FrontFaceStencil = new MTLStencilDescriptor
             {
                 StencilFailureOperation = stencilTest.FrontSFail.Convert(),
                 DepthFailureOperation = stencilTest.FrontDpFail.Convert(),
@@ -347,7 +344,16 @@ namespace Ryujinx.Graphics.Metal
                 ReadMask = (uint)stencilTest.FrontFuncMask,
                 WriteMask = (uint)stencilTest.FrontMask
             };
-            _currentState.FrontFaceStencil = frontFace;
+
+            _currentState.BackFaceStencil = new MTLStencilDescriptor
+            {
+                StencilFailureOperation = stencilTest.BackSFail.Convert(),
+                DepthFailureOperation = stencilTest.BackDpFail.Convert(),
+                DepthStencilPassOperation = stencilTest.BackDpPass.Convert(),
+                StencilCompareFunction = stencilTest.BackFunc.Convert(),
+                ReadMask = (uint)stencilTest.BackFuncMask,
+                WriteMask = (uint)stencilTest.BackMask
+            };
 
             _currentState.StencilTestEnabled = stencilTest.TestEnable;
 
@@ -370,8 +376,6 @@ namespace Ryujinx.Graphics.Metal
 
             // Cleanup
             descriptor.Dispose();
-            frontFace.Dispose();
-            backFace.Dispose();
         }
 
         // Inlineable

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -17,8 +17,8 @@ namespace Ryujinx.Graphics.Metal
         private readonly RenderPipelineCache _renderPipelineCache;
         private readonly DepthStencilCache _depthStencilCache;
 
-        public EncoderState _currentState = new();
-        public List<EncoderState> _backStates = new();
+        private EncoderState _currentState = new();
+        private List<EncoderState> _backStates = new();
 
         public readonly MTLBuffer IndexBuffer => _currentState.IndexBuffer;
         public readonly MTLIndexType IndexType => _currentState.IndexType;

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -134,6 +134,7 @@ namespace Ryujinx.Graphics.Metal
                 SetDepthStencilState(renderCommandEncoder);
             }
 
+            // Clear the dirty flags
             _currentState.Dirty.Clear();
         }
 

--- a/src/Ryujinx.Graphics.Metal/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Metal/HelperShader.cs
@@ -73,9 +73,11 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SaveState();
 
             _pipeline.SetProgram(_programColorBlit);
+            _pipeline.SetFaceCulling(false, Face.Front);
+            _pipeline.SetDepthTest(new DepthTestDescriptor(false, false, CompareOp.Always));
             // Viewport and scissor needs to be set before render pass begin so as not to bind the old ones
-            //_pipeline.SetViewports([]);
-            //_pipeline.SetScissors([]);
+            _pipeline.SetViewports([]);
+            _pipeline.SetScissors([]);
             _pipeline.SetRenderTargets([destination], null);
             _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, source, new Sampler(sampler));
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.Triangles);
@@ -110,6 +112,8 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SetUniformBuffers([new BufferAssignment(0, range)]);
 
             _pipeline.SetProgram(_programsColorClear[index]);
+            _pipeline.SetFaceCulling(false, Face.Front);
+            _pipeline.SetDepthTest(new DepthTestDescriptor(false, false, CompareOp.Always));
             // _pipeline.SetRenderTargetColorMasks([componentMask]);
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.TriangleStrip);
             _pipeline.Draw(4, 1, 0, 0);
@@ -145,6 +149,8 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SetUniformBuffers([new BufferAssignment(0, range)]);
 
             _pipeline.SetProgram(_programDepthStencilClear);
+            _pipeline.SetFaceCulling(false, Face.Front);
+            _pipeline.SetDepthTest(new DepthTestDescriptor(false, false, CompareOp.Always));
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.TriangleStrip);
             _pipeline.SetDepthTest(new DepthTestDescriptor(true, depthMask, CompareOp.Always));
             // _pipeline.SetStencilTest(CreateStencilTestDescriptor(stencilMask != 0, stencilValue, 0xFF, stencilMask));

--- a/src/Ryujinx.Graphics.Metal/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Metal/HelperShader.cs
@@ -73,6 +73,9 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SaveState();
 
             _pipeline.SetProgram(_programColorBlit);
+            // Viewport and scissor needs to be set before render pass begin so as not to bind the old ones
+            //_pipeline.SetViewports([]);
+            //_pipeline.SetScissors([]);
             _pipeline.SetRenderTargets([destination], null);
             _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, source, new Sampler(sampler));
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.Triangles);

--- a/src/Ryujinx.Graphics.Metal/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Metal/HelperShader.cs
@@ -83,7 +83,6 @@ namespace Ryujinx.Graphics.Metal
         }
 
         public unsafe void ClearColor(
-            Texture dst,
             int index,
             ReadOnlySpan<float> clearColor)
         {
@@ -108,7 +107,6 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SetUniformBuffers([new BufferAssignment(0, range)]);
 
             _pipeline.SetProgram(_programsColorClear[index]);
-            _pipeline.SetRenderTargets([dst], null);
             // _pipeline.SetRenderTargetColorMasks([componentMask]);
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.TriangleStrip);
             _pipeline.Draw(4, 1, 0, 0);
@@ -118,7 +116,6 @@ namespace Ryujinx.Graphics.Metal
         }
 
         public unsafe void ClearDepthStencil(
-            Texture dst,
             ReadOnlySpan<float> depthValue,
             bool depthMask,
             int stencilValue,

--- a/src/Ryujinx.Graphics.Metal/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Metal/HelperShader.cs
@@ -64,12 +64,17 @@ namespace Ryujinx.Graphics.Metal
                 MipFilter = MTLSamplerMipFilter.NotMipmapped
             });
 
+            // Save current state
+            _pipeline.SaveState();
+
             _pipeline.SetProgram(_programColorBlit);
             _pipeline.SetRenderTargets([destination], null);
             _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, source, new Sampler(sampler));
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.Triangles);
             _pipeline.Draw(6, 1, 0, 0);
-            _pipeline.Finish();
+
+            // Restore previous state
+            _pipeline.RestoreState();
         }
 
         public unsafe void ClearColor(
@@ -91,6 +96,9 @@ namespace Ryujinx.Graphics.Metal
             var handle = buffer.NativePtr;
             var range = new BufferRange(Unsafe.As<IntPtr, BufferHandle>(ref handle), 0, ClearColorBufferSize);
 
+            // Save current state
+            _pipeline.SaveState();
+
             _pipeline.SetUniformBuffers([new BufferAssignment(0, range)]);
 
             _pipeline.SetProgram(_programColorClear);
@@ -98,7 +106,9 @@ namespace Ryujinx.Graphics.Metal
             // _pipeline.SetRenderTargetColorMasks([componentMask]);
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.TriangleStrip);
             _pipeline.Draw(4, 1, 0, 0);
-            _pipeline.Finish();
+
+            // Restore previous state
+            _pipeline.RestoreState();
         }
 
         public unsafe void ClearDepthStencil(
@@ -123,15 +133,19 @@ namespace Ryujinx.Graphics.Metal
             var handle = buffer.NativePtr;
             var range = new BufferRange(Unsafe.As<IntPtr, BufferHandle>(ref handle), 0, ClearColorBufferSize);
 
+            // Save current state
+            _pipeline.SaveState();
+
             _pipeline.SetUniformBuffers([new BufferAssignment(0, range)]);
 
             _pipeline.SetProgram(_programDepthStencilClear);
-            _pipeline.SetRenderTargets([], dst);
             _pipeline.SetPrimitiveTopology(PrimitiveTopology.TriangleStrip);
             _pipeline.SetDepthTest(new DepthTestDescriptor(true, depthMask, CompareOp.Always));
             // _pipeline.SetStencilTest(CreateStencilTestDescriptor(stencilMask != 0, stencilValue, 0xFF, stencilMask));
             _pipeline.Draw(4, 1, 0, 0);
-            _pipeline.Finish();
+
+            // Restore previous state
+            _pipeline.RestoreState();
         }
 
         private static StencilTestDescriptor CreateStencilTestDescriptor(

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -19,26 +19,6 @@ namespace Ryujinx.Graphics.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    struct ColorClear
-    {
-        public int Layer;
-        public int LayerCount;
-        public uint ComponentMask;
-        public ColorF Color;
-    }
-
-    [SupportedOSPlatform("macos")]
-    struct DepthStencilClear
-    {
-        public int Layer;
-        public int LayerCount;
-        public float DepthValue;
-        public bool DepthMask;
-        public int StencilValue;
-        public int StencilMask;
-    }
-
-    [SupportedOSPlatform("macos")]
     class Pipeline : IPipeline, IDisposable
     {
         private readonly MTLDevice _device;
@@ -55,10 +35,6 @@ namespace Ryujinx.Graphics.Metal
         public EncoderType CurrentEncoderType => _currentEncoderType;
 
         private EncoderStateManager _encoderStateManager;
-
-        // Deferred clears
-        private ColorClear?[] _colorClears = new ColorClear?[Constants.MaxColorAttachments];
-        private DepthStencilClear? _depthStencilClear;
 
         public Pipeline(MTLDevice device, MTLCommandQueue commandQueue)
         {
@@ -176,38 +152,6 @@ namespace Ryujinx.Graphics.Metal
             return computeCommandEncoder;
         }
 
-        public void ExecuteDeferredColorClears()
-        {
-            for (int i = 0; i < Constants.MaxColorAttachments; i++)
-            {
-                if (_colorClears[i] != null)
-                {
-                    ColorF color = _colorClears[i].Value.Color;
-                    float[] colors = [color.Red, color.Green, color.Blue, color.Alpha];
-
-                    Texture target = _encoderStateManager.RenderTargets[i];
-
-                    _encoderStateManager.SwapStates();
-
-                    _helperShader.ClearColor(target, colors);
-                }
-                _colorClears[i] = null;
-            }
-        }
-
-        public void ExecuteDeferredDepthStencilClear()
-        {
-            if (_depthStencilClear != null)
-            {
-                Texture target = _encoderStateManager.DepthStencil;
-
-                _encoderStateManager.SwapStates();
-
-                _helperShader.ClearDepthStencil(target, [_depthStencilClear.Value.DepthValue], _depthStencilClear.Value.DepthMask, _depthStencilClear.Value.StencilValue, _depthStencilClear.Value.StencilMask);
-            }
-            _depthStencilClear = null;
-        }
-
         public void Present(CAMetalDrawable drawable, ITexture texture)
         {
             if (texture is not Texture tex)
@@ -259,30 +203,22 @@ namespace Ryujinx.Graphics.Metal
 
         public void ClearRenderTargetColor(int index, int layer, int layerCount, uint componentMask, ColorF color)
         {
-            _colorClears[index] = new ColorClear
-            {
-                Layer = layer,
-                LayerCount = layerCount,
-                ComponentMask = componentMask,
-                Color = color
-            };
+            float[] colors = [color.Red, color.Green, color.Blue, color.Alpha];
 
-            ExecuteDeferredColorClears();
+            Texture target = _encoderStateManager.RenderTargets[index];
+
+            _encoderStateManager.SwapStates();
+
+            _helperShader.ClearColor(target, colors);
         }
 
         public void ClearRenderTargetDepthStencil(int layer, int layerCount, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
-            _depthStencilClear = new DepthStencilClear
-            {
-                Layer = layer,
-                LayerCount = layerCount,
-                DepthValue = depthValue,
-                DepthMask = depthMask,
-                StencilValue = stencilValue,
-                StencilMask = stencilMask
-            };
+            Texture target = _encoderStateManager.DepthStencil;
 
-            ExecuteDeferredDepthStencilClear();
+            _encoderStateManager.SwapStates();
+
+            _helperShader.ClearDepthStencil(target, [depthValue], depthMask, stencilValue, stencilMask);
         }
 
         public void CommandBufferBarrier()

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -187,6 +187,9 @@ namespace Ryujinx.Graphics.Metal
             _commandBuffer = _commandQueue.CommandBuffer();
 
             RestoreState();
+
+            // Cleanup
+            dest.Dispose();
         }
 
         public void Barrier()

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -191,7 +191,22 @@ namespace Ryujinx.Graphics.Metal
 
         public void Barrier()
         {
-            Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
+
+            if (_currentEncoderType == EncoderType.Render)
+            {
+                var renderCommandEncoder = GetOrCreateRenderEncoder();
+
+                var scope = MTLBarrierScope.Buffers | MTLBarrierScope.Textures | MTLBarrierScope.RenderTargets;
+                MTLRenderStages stages = MTLRenderStages.RenderStageVertex | MTLRenderStages.RenderStageFragment;
+                renderCommandEncoder.MemoryBarrier(scope, stages, stages);
+            } else if (_currentEncoderType == EncoderType.Compute)
+            {
+                var computeCommandEncoder = GetOrCreateComputeEncoder();
+
+                // TODO: Should there be a barrier on render targets?
+                var scope = MTLBarrierScope.Buffers | MTLBarrierScope.Textures;
+                computeCommandEncoder.MemoryBarrier(scope);
+            }
         }
 
         public void ClearBuffer(BufferHandle destination, int offset, int size, uint value)

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -206,6 +206,9 @@ namespace Ryujinx.Graphics.Metal
                 // TODO: Should there be a barrier on render targets?
                 var scope = MTLBarrierScope.Buffers | MTLBarrierScope.Textures;
                 computeCommandEncoder.MemoryBarrier(scope);
+            } else
+            {
+                Logger.Warning?.Print(LogClass.Gpu, "Barrier called outside of a render or compute pass");
             }
         }
 

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -216,7 +216,7 @@ namespace Ryujinx.Graphics.Metal
 
             Texture target = _encoderStateManager.RenderTargets[index];
 
-            _helperShader.ClearColor(target, colors);
+            _helperShader.ClearColor(target, index, colors);
         }
 
         public void ClearRenderTargetDepthStencil(int layer, int layerCount, float depthValue, bool depthMask, int stencilValue, int stencilMask)

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -445,26 +445,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void SetScissors(ReadOnlySpan<Rectangle<int>> regions)
         {
-            // TODO: Test max allowed scissor rects on device
-            var mtlScissorRects = new MTLScissorRect[regions.Length];
-
-            for (int i = 0; i < regions.Length; i++)
-            {
-                var region = regions[i];
-                mtlScissorRects[i] = new MTLScissorRect
-                {
-                    height = (ulong)region.Height,
-                    width = (ulong)region.Width,
-                    x = (ulong)region.X,
-                    y = (ulong)region.Y
-                };
-            }
-
-            fixed (MTLScissorRect* pMtlScissorRects = mtlScissorRects)
-            {
-                var renderCommandEncoder = GetOrCreateRenderEncoder();
-                renderCommandEncoder.SetScissorRects((IntPtr)pMtlScissorRects, (ulong)regions.Length);
-            }
+            _encoderStateManager.UpdateScissors(regions);
         }
 
         public void SetStencilTest(StencilTestDescriptor stencilTest)
@@ -532,28 +513,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void SetViewports(ReadOnlySpan<Viewport> viewports)
         {
-            // TODO: Test max allowed viewports on device
-            var mtlViewports = new MTLViewport[viewports.Length];
-
-            for (int i = 0; i < viewports.Length; i++)
-            {
-                var viewport = viewports[i];
-                mtlViewports[i] = new MTLViewport
-                {
-                    originX = viewport.Region.X,
-                    originY = viewport.Region.Y,
-                    width = viewport.Region.Width,
-                    height = viewport.Region.Height,
-                    znear = viewport.DepthNear,
-                    zfar = viewport.DepthFar
-                };
-            }
-
-            fixed (MTLViewport* pMtlViewports = mtlViewports)
-            {
-                var renderCommandEncoder = GetOrCreateRenderEncoder();
-                renderCommandEncoder.SetViewports((IntPtr)pMtlViewports, (ulong)viewports.Length);
-            }
+            _encoderStateManager.UpdateViewports(viewports);
         }
 
         public void TextureBarrier()

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -440,7 +440,26 @@ namespace Ryujinx.Graphics.Metal
 
         public void SetScissors(ReadOnlySpan<Rectangle<int>> regions)
         {
-            _encoderStateManager.UpdateScissors(regions);
+            // TODO: Test max allowed scissor rects on device
+            var mtlScissorRects = new MTLScissorRect[regions.Length];
+
+            for (int i = 0; i < regions.Length; i++)
+            {
+                var region = regions[i];
+                mtlScissorRects[i] = new MTLScissorRect
+                {
+                    height = (ulong)region.Height,
+                    width = (ulong)region.Width,
+                    x = (ulong)region.X,
+                    y = (ulong)region.Y
+                };
+            }
+
+            fixed (MTLScissorRect* pMtlScissorRects = mtlScissorRects)
+            {
+                var renderCommandEncoder = GetOrCreateRenderEncoder();
+                renderCommandEncoder.SetScissorRects((IntPtr)pMtlScissorRects, (ulong)regions.Length);
+            }
         }
 
         public void SetStencilTest(StencilTestDescriptor stencilTest)
@@ -508,7 +527,28 @@ namespace Ryujinx.Graphics.Metal
 
         public void SetViewports(ReadOnlySpan<Viewport> viewports)
         {
-            _encoderStateManager.UpdateViewports(viewports);
+            // TODO: Test max allowed viewports on device
+            var mtlViewports = new MTLViewport[viewports.Length];
+
+            for (int i = 0; i < viewports.Length; i++)
+            {
+                var viewport = viewports[i];
+                mtlViewports[i] = new MTLViewport
+                {
+                    originX = viewport.Region.X,
+                    originY = viewport.Region.Y,
+                    width = viewport.Region.Width,
+                    height = viewport.Region.Height,
+                    znear = viewport.DepthNear,
+                    zfar = viewport.DepthFar
+                };
+            }
+
+            fixed (MTLViewport* pMtlViewports = mtlViewports)
+            {
+                var renderCommandEncoder = GetOrCreateRenderEncoder();
+                renderCommandEncoder.SetViewports((IntPtr)pMtlViewports, (ulong)viewports.Length);
+            }
         }
 
         public void TextureBarrier()

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -46,6 +46,16 @@ namespace Ryujinx.Graphics.Metal
             _encoderStateManager = new EncoderStateManager(_device, this);
         }
 
+        public void SaveState()
+        {
+            _encoderStateManager.SaveState();
+        }
+
+        public void RestoreState()
+        {
+            _encoderStateManager.RestoreState();
+        }
+
         public MTLRenderCommandEncoder GetOrCreateRenderEncoder()
         {
             MTLRenderCommandEncoder renderCommandEncoder;
@@ -161,7 +171,7 @@ namespace Ryujinx.Graphics.Metal
 
             EndCurrentPass();
 
-            _encoderStateManager.SwapStates();
+            SaveState();
 
             // TODO: Clean this up
             var textureInfo = new TextureCreateInfo((int)drawable.Texture.Width, (int)drawable.Texture.Height, (int)drawable.Texture.Depth, (int)drawable.Texture.MipmapLevelCount, (int)drawable.Texture.SampleCount, 0, 0, 0, Format.B8G8R8A8Unorm, 0, Target.Texture2D, SwizzleComponent.Red, SwizzleComponent.Green, SwizzleComponent.Blue, SwizzleComponent.Alpha);
@@ -169,15 +179,14 @@ namespace Ryujinx.Graphics.Metal
 
             _helperShader.BlitColor(tex, dest);
 
+            EndCurrentPass();
+
             _commandBuffer.PresentDrawable(drawable);
             _commandBuffer.Commit();
 
             _commandBuffer = _commandQueue.CommandBuffer();
-        }
 
-        public void Finish()
-        {
-            _encoderStateManager.SwapStates();
+            RestoreState();
         }
 
         public void Barrier()
@@ -207,16 +216,12 @@ namespace Ryujinx.Graphics.Metal
 
             Texture target = _encoderStateManager.RenderTargets[index];
 
-            _encoderStateManager.SwapStates();
-
             _helperShader.ClearColor(target, colors);
         }
 
         public void ClearRenderTargetDepthStencil(int layer, int layerCount, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
             Texture target = _encoderStateManager.DepthStencil;
-
-            _encoderStateManager.SwapStates();
 
             _helperShader.ClearDepthStencil(target, [depthValue], depthMask, stencilValue, stencilMask);
         }

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -214,16 +214,12 @@ namespace Ryujinx.Graphics.Metal
         {
             float[] colors = [color.Red, color.Green, color.Blue, color.Alpha];
 
-            Texture target = _encoderStateManager.RenderTargets[index];
-
-            _helperShader.ClearColor(target, index, colors);
+            _helperShader.ClearColor(index, colors);
         }
 
         public void ClearRenderTargetDepthStencil(int layer, int layerCount, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
-            Texture target = _encoderStateManager.DepthStencil;
-
-            _helperShader.ClearDepthStencil(target, [depthValue], depthMask, stencilValue, stencilMask);
+            _helperShader.ClearDepthStencil([depthValue], depthMask, stencilValue, stencilMask);
         }
 
         public void CommandBufferBarrier()

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -577,6 +577,7 @@ namespace Ryujinx.Graphics.Metal
         public void Dispose()
         {
             EndCurrentPass();
+            _encoderStateManager.Dispose();
         }
     }
 }

--- a/src/Ryujinx.Graphics.Metal/Shaders/ColorClear.metal
+++ b/src/Ryujinx.Graphics.Metal/Shaders/ColorClear.metal
@@ -6,8 +6,7 @@ struct VertexOut {
     float4 position [[position]];
 };
 
-vertex VertexOut vertexMain(ushort vid [[vertex_id]])
-{
+vertex VertexOut vertexMain(ushort vid [[vertex_id]]) {
     int low = vid & 1;
     int high = vid >> 1;
 
@@ -21,8 +20,11 @@ vertex VertexOut vertexMain(ushort vid [[vertex_id]])
     return out;
 }
 
-fragment float4 fragmentMain(VertexOut in [[stage_in]],
-                             constant float4& clear_color [[buffer(0)]])
-{
-    return clear_color;
+struct FragmentOut {
+    float4 color [[color(COLOR_ATTACHMENT_INDEX)]];
+};
+
+fragment FragmentOut fragmentMain(VertexOut in [[stage_in]],
+                                  constant float4& clear_color [[buffer(0)]]) {
+    return {clear_color};
 }

--- a/src/Ryujinx.Graphics.Metal/Shaders/DepthStencilClear.metal
+++ b/src/Ryujinx.Graphics.Metal/Shaders/DepthStencilClear.metal
@@ -11,8 +11,7 @@ struct FragmentOut {
     uint stencil [[stencil]];
 };
 
-vertex VertexOut vertexMain(ushort vid [[vertex_id]])
-{
+vertex VertexOut vertexMain(ushort vid [[vertex_id]]) {
     int low = vid & 1;
     int high = vid >> 1;
 
@@ -27,11 +26,10 @@ vertex VertexOut vertexMain(ushort vid [[vertex_id]])
 }
 
 fragment FragmentOut fragmentMain(VertexOut in [[stage_in]],
-                                  constant float& clear_color [[buffer(0)]])
-{
+                                  constant float& clear_depth [[buffer(0)]]) {
     FragmentOut out;
 
-    out.depth = clear_color;
+    out.depth = clear_depth;
     // out.stencil = stencil_clear;
 
     return out;

--- a/src/Ryujinx.Graphics.Metal/StateCache.cs
+++ b/src/Ryujinx.Graphics.Metal/StateCache.cs
@@ -1,16 +1,25 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
 
 namespace Ryujinx.Graphics.Metal
 {
     [SupportedOSPlatform("macos")]
-    public abstract class StateCache<T, TDescriptor, THash>
+    public abstract class StateCache<T, TDescriptor, THash> : IDisposable where T : IDisposable
     {
         private readonly Dictionary<THash, T> _cache = new();
 
         protected abstract THash GetHash(TDescriptor descriptor);
 
         protected abstract T CreateValue(TDescriptor descriptor);
+
+        public void Dispose()
+        {
+            foreach (T value in _cache.Values)
+            {
+                value.Dispose();
+            }
+        }
 
         public T GetOrCreate(TDescriptor descriptor)
         {

--- a/src/Ryujinx.Graphics.Metal/Texture.cs
+++ b/src/Ryujinx.Graphics.Metal/Texture.cs
@@ -223,7 +223,7 @@ namespace Ryujinx.Graphics.Metal
                 );
 
                 // TODO: Dispose the buffer
-                return new PinnedSpan<byte>(mtlBuffer.Contents.ToPointer(), (int)length);
+                return new PinnedSpan<byte>(mtlBuffer.Contents.ToPointer(), (int)length, () => mtlBuffer.Dispose());
             }
         }
 

--- a/src/Ryujinx.Graphics.Metal/Texture.cs
+++ b/src/Ryujinx.Graphics.Metal/Texture.cs
@@ -222,7 +222,6 @@ namespace Ryujinx.Graphics.Metal
                     bytesPerImage
                 );
 
-                // TODO: Dispose the buffer
                 return new PinnedSpan<byte>(mtlBuffer.Contents.ToPointer(), (int)length, () => mtlBuffer.Dispose());
             }
         }
@@ -278,6 +277,9 @@ namespace Ryujinx.Graphics.Metal
                     depth = Math.Max(1, depth >> 1);
                 }
             }
+
+            // Cleanup
+            mtlBuffer.Dispose();
         }
 
         public void SetData(IMemoryOwner<byte> data, int layer, int level)
@@ -309,6 +311,9 @@ namespace Ryujinx.Graphics.Metal
                     (ulong)level,
                     new MTLOrigin()
                 );
+
+                // Cleanup
+                mtlBuffer.Dispose();
             }
         }
 
@@ -341,6 +346,9 @@ namespace Ryujinx.Graphics.Metal
                     (ulong)level,
                     new MTLOrigin { x = (ulong)region.X, y = (ulong)region.Y }
                 );
+
+                // Cleanup
+                mtlBuffer.Dispose();
             }
         }
 


### PR DESCRIPTION
The texture clears now don't interrupt the render pass. It's straightforward with depth stencil clears, but not so with color clears. In that case, there are 8 different programs, each having a different output color attachment index and the backend automatically chooses one of these programs when clearing (There might be a better way to do this). The clears want to use the same state that was there before the clear, so there is a push and pop system for the states. This also fixed some of the issues with Rayman Legends and improved the performance as well.

Barriers are implemented as well, which fixed flickering in certain games.