### PR TITLE
don't recreate render pipeline unless we're about to draw, pass view depth properly

### DIFF
--- a/src/Ryujinx.Graphics.Metal/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Metal/HelperShader.cs
@@ -122,7 +122,7 @@ namespace Ryujinx.Graphics.Metal
 
             fixed (float* ptr = region)
             {
-                _pipeline.GetOrCreateRenderEncoder().SetVertexBytes((IntPtr)ptr, RegionBufferSize, 0);
+                _pipeline.GetOrCreateRenderEncoder(true).SetVertexBytes((IntPtr)ptr, RegionBufferSize, 0);
             }
 
             _pipeline.Draw(4, 1, 0, 0);
@@ -191,7 +191,7 @@ namespace Ryujinx.Graphics.Metal
 
             fixed (float* ptr = region)
             {
-                _pipeline.GetOrCreateRenderEncoder().SetVertexBytes((IntPtr)ptr, RegionBufferSize, 0);
+                _pipeline.GetOrCreateRenderEncoder(true).SetVertexBytes((IntPtr)ptr, RegionBufferSize, 0);
             }
 
             _pipeline.Draw(4, 1, 0, 0);
@@ -234,7 +234,7 @@ namespace Ryujinx.Graphics.Metal
 
             fixed (float* ptr = clearColor)
             {
-                _pipeline.GetOrCreateRenderEncoder().SetFragmentBytes((IntPtr)ptr, ClearColorBufferSize, 0);
+                _pipeline.GetOrCreateRenderEncoder(true).SetFragmentBytes((IntPtr)ptr, ClearColorBufferSize, 0);
             }
 
             _pipeline.Draw(4, 1, 0, 0);
@@ -276,7 +276,7 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SetViewports(viewports);
             _pipeline.SetDepthTest(new DepthTestDescriptor(true, depthMask, CompareOp.Always));
             // _pipeline.SetStencilTest(CreateStencilTestDescriptor(stencilMask != 0, stencilValue, 0xFF, stencilMask));
-            _pipeline.GetOrCreateRenderEncoder().SetFragmentBytes(ptr, ClearDepthBufferSize, 0);
+            _pipeline.GetOrCreateRenderEncoder(true).SetFragmentBytes(ptr, ClearDepthBufferSize, 0);
             _pipeline.Draw(4, 1, 0, 0);
 
             // Restore previous state

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -72,7 +72,7 @@ namespace Ryujinx.Graphics.Metal
             _encoderStateManager.SetClearLoadAction(clear);
         }
 
-        public MTLRenderCommandEncoder GetOrCreateRenderEncoder()
+        public MTLRenderCommandEncoder GetOrCreateRenderEncoder(bool forDraw = false)
         {
             MTLRenderCommandEncoder renderCommandEncoder;
             if (_currentEncoder == null || _currentEncoderType != EncoderType.Render)
@@ -84,7 +84,10 @@ namespace Ryujinx.Graphics.Metal
                 renderCommandEncoder = new MTLRenderCommandEncoder(_currentEncoder.Value);
             }
 
-            _encoderStateManager.RebindRenderState(renderCommandEncoder);
+            if (forDraw)
+            {
+                _encoderStateManager.RebindRenderState(renderCommandEncoder);
+            }
 
             return renderCommandEncoder;
         }
@@ -306,7 +309,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void Draw(int vertexCount, int instanceCount, int firstVertex, int firstInstance)
         {
-            var renderCommandEncoder = GetOrCreateRenderEncoder();
+            var renderCommandEncoder = GetOrCreateRenderEncoder(true);
 
             // TODO: Support topology re-indexing to provide support for TriangleFans
             var primitiveType = _encoderStateManager.Topology.Convert();
@@ -321,7 +324,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void DrawIndexed(int indexCount, int instanceCount, int firstIndex, int firstVertex, int firstInstance)
         {
-            var renderCommandEncoder = GetOrCreateRenderEncoder();
+            var renderCommandEncoder = GetOrCreateRenderEncoder(true);
 
             // TODO: Support topology re-indexing to provide support for TriangleFans
             var primitiveType = _encoderStateManager.Topology.Convert();
@@ -341,28 +344,28 @@ namespace Ryujinx.Graphics.Metal
 
         public void DrawIndexedIndirect(BufferRange indirectBuffer)
         {
-            // var renderCommandEncoder = GetOrCreateRenderEncoder();
+            // var renderCommandEncoder = GetOrCreateRenderEncoder(true);
 
             Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
         }
 
         public void DrawIndexedIndirectCount(BufferRange indirectBuffer, BufferRange parameterBuffer, int maxDrawCount, int stride)
         {
-            // var renderCommandEncoder = GetOrCreateRenderEncoder();
+            // var renderCommandEncoder = GetOrCreateRenderEncoder(true);
 
             Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
         }
 
         public void DrawIndirect(BufferRange indirectBuffer)
         {
-            // var renderCommandEncoder = GetOrCreateRenderEncoder();
+            // var renderCommandEncoder = GetOrCreateRenderEncoder(true);
 
             Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
         }
 
         public void DrawIndirectCount(BufferRange indirectBuffer, BufferRange parameterBuffer, int maxDrawCount, int stride)
         {
-            // var renderCommandEncoder = GetOrCreateRenderEncoder();
+            // var renderCommandEncoder = GetOrCreateRenderEncoder(true);
 
             Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
         }

--- a/src/Ryujinx.Graphics.Metal/Texture.cs
+++ b/src/Ryujinx.Graphics.Metal/Texture.cs
@@ -46,12 +46,7 @@ namespace Ryujinx.Graphics.Metal
             levels.length = (ulong)Info.Levels;
             NSRange slices;
             slices.location = (ulong)firstLayer;
-            slices.length = 1;
-
-            if (info.Target != Target.Texture3D && info.Target != Target.Cubemap)
-            {
-                slices.length = (ulong)Info.Depth;
-            }
+            slices.length = (ulong)Info.Depth;
 
             var swizzle = GetSwizzle(info, pixelFormat);
 


### PR DESCRIPTION
Fixes some crashes when booting Mario Kart 8 Deluxe. The render pipeline state should only be compiled immediately before a draw, because it's possible for it to be invalid at any other time.