### PR TITLE
Preload command speedup, Texture/buffer data flush, blit shader fix

### DIFF
--- a/src/Ryujinx.Graphics.Metal/BackgroundResources.cs
+++ b/src/Ryujinx.Graphics.Metal/BackgroundResources.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.Graphics.Metal
             {
                 MTLCommandQueue queue = _renderer.BackgroundQueue;
                 _pool = new CommandBufferPool(queue);
+                _pool.Initialize(null); // TODO: Proper encoder factory for background render/compute
             }
 
             return _pool;

--- a/src/Ryujinx.Graphics.Metal/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Metal/BufferManager.cs
@@ -176,14 +176,14 @@ namespace Ryujinx.Graphics.Metal
 
         public void SetData<T>(BufferHandle handle, int offset, ReadOnlySpan<T> data) where T : unmanaged
         {
-            SetData(handle, offset, MemoryMarshal.Cast<T, byte>(data), null, null);
+            SetData(handle, offset, MemoryMarshal.Cast<T, byte>(data), null);
         }
 
-        public void SetData(BufferHandle handle, int offset, ReadOnlySpan<byte> data, CommandBufferScoped? cbs, Action endRenderPass)
+        public void SetData(BufferHandle handle, int offset, ReadOnlySpan<byte> data, CommandBufferScoped? cbs)
         {
             if (TryGetBuffer(handle, out var holder))
             {
-                holder.SetData(offset, data, cbs, endRenderPass);
+                holder.SetData(offset, data, cbs);
             }
         }
 

--- a/src/Ryujinx.Graphics.Metal/CommandBufferEncoder.cs
+++ b/src/Ryujinx.Graphics.Metal/CommandBufferEncoder.cs
@@ -1,0 +1,170 @@
+using Ryujinx.Graphics.Metal;
+using SharpMetal.Metal;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+
+interface IEncoderFactory
+{
+    MTLRenderCommandEncoder CreateRenderCommandEncoder();
+    MTLComputeCommandEncoder CreateComputeCommandEncoder();
+}
+
+/// <summary>
+/// Tracks active encoder object for a command buffer.
+/// </summary>
+[SupportedOSPlatform("macos")]
+class CommandBufferEncoder
+{
+    public EncoderType CurrentEncoderType { get; private set; } = EncoderType.None;
+
+    public MTLBlitCommandEncoder BlitEncoder => new MTLBlitCommandEncoder(CurrentEncoder.Value);
+
+    public MTLComputeCommandEncoder ComputeEncoder => new MTLComputeCommandEncoder(CurrentEncoder.Value);
+
+    public MTLRenderCommandEncoder RenderEncoder => new MTLRenderCommandEncoder(CurrentEncoder.Value);
+
+    internal MTLCommandEncoder? CurrentEncoder { get; private set; }
+
+    private MTLCommandBuffer _commandBuffer;
+    private IEncoderFactory _encoderFactory;
+
+    public void Initialize(MTLCommandBuffer commandBuffer, IEncoderFactory encoderFactory)
+    {
+        _commandBuffer = commandBuffer;
+        _encoderFactory = encoderFactory;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MTLRenderCommandEncoder EnsureRenderEncoder()
+    {
+        if (CurrentEncoderType != EncoderType.Render)
+        {
+            return BeginRenderPass();
+        }
+
+        return RenderEncoder;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MTLBlitCommandEncoder EnsureBlitEncoder()
+    {
+        if (CurrentEncoderType != EncoderType.Blit)
+        {
+            return BeginBlitPass();
+        }
+
+        return BlitEncoder;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MTLComputeCommandEncoder EnsureComputeEncoder()
+    {
+        if (CurrentEncoderType != EncoderType.Compute)
+        {
+            return BeginComputePass();
+        }
+
+        return ComputeEncoder;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetRenderEncoder(out MTLRenderCommandEncoder encoder)
+    {
+        if (CurrentEncoderType != EncoderType.Render)
+        {
+            encoder = default;
+            return false;
+        }
+
+        encoder = RenderEncoder;
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetBlitEncoder(out MTLBlitCommandEncoder encoder)
+    {
+        if (CurrentEncoderType != EncoderType.Blit)
+        {
+            encoder = default;
+            return false;
+        }
+
+        encoder = BlitEncoder;
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetComputeEncoder(out MTLComputeCommandEncoder encoder)
+    {
+        if (CurrentEncoderType != EncoderType.Compute)
+        {
+            encoder = default;
+            return false;
+        }
+
+        encoder = ComputeEncoder;
+        return true;
+    }
+
+    public void EndCurrentPass()
+    {
+        if (CurrentEncoder != null)
+        {
+            switch (CurrentEncoderType)
+            {
+                case EncoderType.Blit:
+                    BlitEncoder.EndEncoding();
+                    CurrentEncoder = null;
+                    break;
+                case EncoderType.Compute:
+                    ComputeEncoder.EndEncoding();
+                    CurrentEncoder = null;
+                    break;
+                case EncoderType.Render:
+                    RenderEncoder.EndEncoding();
+                    CurrentEncoder = null;
+                    break;
+                default:
+                    throw new InvalidOperationException();
+            }
+
+            CurrentEncoderType = EncoderType.None;
+        }
+    }
+
+    private MTLRenderCommandEncoder BeginRenderPass()
+    {
+        EndCurrentPass();
+
+        var renderCommandEncoder = _encoderFactory.CreateRenderCommandEncoder();
+
+        CurrentEncoder = renderCommandEncoder;
+        CurrentEncoderType = EncoderType.Render;
+
+        return renderCommandEncoder;
+    }
+
+    private MTLBlitCommandEncoder BeginBlitPass()
+    {
+        EndCurrentPass();
+
+        var descriptor = new MTLBlitPassDescriptor();
+        var blitCommandEncoder = _commandBuffer.BlitCommandEncoder(descriptor);
+
+        CurrentEncoder = blitCommandEncoder;
+        CurrentEncoderType = EncoderType.Blit;
+        return blitCommandEncoder;
+    }
+
+    private MTLComputeCommandEncoder BeginComputePass()
+    {
+        EndCurrentPass();
+
+        var computeCommandEncoder = _encoderFactory.CreateComputeCommandEncoder();
+
+        CurrentEncoder = computeCommandEncoder;
+        CurrentEncoderType = EncoderType.Compute;
+        return computeCommandEncoder;
+    }
+}

--- a/src/Ryujinx.Graphics.Metal/CommandBufferPool.cs
+++ b/src/Ryujinx.Graphics.Metal/CommandBufferPool.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.Graphics.Metal
         private readonly int _totalCommandBuffers;
         private readonly int _totalCommandBuffersMask;
         private readonly MTLCommandQueue _queue;
+        private IEncoderFactory _defaultEncoderFactory;
 
         [SupportedOSPlatform("macos")]
         private struct ReservedCommandBuffer
@@ -22,22 +23,28 @@ namespace Ryujinx.Graphics.Metal
             public bool InConsumption;
             public int SubmissionCount;
             public MTLCommandBuffer CommandBuffer;
+            public CommandBufferEncoder Encoders;
             public FenceHolder Fence;
 
             public List<IAuto> Dependants;
             public List<MultiFenceHolder> Waitables;
 
-            public void Reinitialize(MTLCommandQueue queue)
+            public void Reinitialize(MTLCommandQueue queue, IEncoderFactory stateManager)
             {
                 CommandBuffer = queue.CommandBuffer();
+
+                Encoders.Initialize(CommandBuffer, stateManager);
             }
 
-            public void Initialize(MTLCommandQueue queue)
+            public void Initialize(MTLCommandQueue queue, IEncoderFactory stateManager)
             {
                 CommandBuffer = queue.CommandBuffer();
 
                 Dependants = new List<IAuto>();
                 Waitables = new List<MultiFenceHolder>();
+                Encoders = new CommandBufferEncoder();
+
+                Encoders.Initialize(CommandBuffer, stateManager);
             }
         }
 
@@ -60,10 +67,15 @@ namespace Ryujinx.Graphics.Metal
             _queuedIndexes = new int[_totalCommandBuffers];
             _queuedIndexesPtr = 0;
             _queuedCount = 0;
+        }
+
+        public void Initialize(IEncoderFactory encoderFactory)
+        {
+            _defaultEncoderFactory = encoderFactory;
 
             for (int i = 0; i < _totalCommandBuffers; i++)
             {
-                _commandBuffers[i].Initialize(_queue);
+                _commandBuffers[i].Initialize(_queue, _defaultEncoderFactory);
                 WaitAndDecrementRef(i);
             }
         }
@@ -194,7 +206,7 @@ namespace Ryujinx.Graphics.Metal
 
                         _inUseCount++;
 
-                        return new CommandBufferScoped(this, entry.CommandBuffer, cursor);
+                        return new CommandBufferScoped(this, entry.CommandBuffer, entry.Encoders, cursor);
                     }
 
                     cursor = (cursor + 1) & _totalCommandBuffersMask;
@@ -223,7 +235,7 @@ namespace Ryujinx.Graphics.Metal
                 commandBuffer.Commit();
 
                 // Replace entry with new MTLCommandBuffer
-                entry.Reinitialize(_queue);
+                entry.Reinitialize(_queue, _defaultEncoderFactory);
 
                 int ptr = (_queuedIndexesPtr + _queuedCount) % _totalCommandBuffers;
                 _queuedIndexes[ptr] = cbIndex;

--- a/src/Ryujinx.Graphics.Metal/CommandBufferScoped.cs
+++ b/src/Ryujinx.Graphics.Metal/CommandBufferScoped.cs
@@ -9,12 +9,14 @@ namespace Ryujinx.Graphics.Metal
     {
         private readonly CommandBufferPool _pool;
         public MTLCommandBuffer CommandBuffer { get; }
+        public CommandBufferEncoder Encoders { get; }
         public int CommandBufferIndex { get; }
 
-        public CommandBufferScoped(CommandBufferPool pool, MTLCommandBuffer commandBuffer, int commandBufferIndex)
+        public CommandBufferScoped(CommandBufferPool pool, MTLCommandBuffer commandBuffer, CommandBufferEncoder encoders, int commandBufferIndex)
         {
             _pool = pool;
             CommandBuffer = commandBuffer;
+            Encoders = encoders;
             CommandBufferIndex = commandBufferIndex;
         }
 

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -581,9 +581,8 @@ namespace Ryujinx.Graphics.Metal
             _currentState.DepthClipMode = clamp ? MTLDepthClipMode.Clamp : MTLDepthClipMode.Clip;
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetDepthClamp(renderCommandEncoder);
                 return;
             }
@@ -600,9 +599,8 @@ namespace Ryujinx.Graphics.Metal
             _currentState.Clamp = clamp;
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetDepthBias(renderCommandEncoder);
                 return;
             }
@@ -632,9 +630,8 @@ namespace Ryujinx.Graphics.Metal
             }
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetScissors(renderCommandEncoder);
                 return;
             }
@@ -669,9 +666,8 @@ namespace Ryujinx.Graphics.Metal
             }
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetViewports(renderCommandEncoder);
                 return;
             }
@@ -688,9 +684,8 @@ namespace Ryujinx.Graphics.Metal
             UpdatePipelineVertexState(_currentState.VertexBuffers, _currentState.VertexAttribs);
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetVertexBuffers(renderCommandEncoder, _currentState.VertexBuffers);
                 return;
             }
@@ -755,9 +750,8 @@ namespace Ryujinx.Graphics.Metal
             _currentState.CullBoth = face == Face.FrontAndBack;
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetCullMode(renderCommandEncoder);
                 SetScissors(renderCommandEncoder);
                 return;
@@ -778,9 +772,8 @@ namespace Ryujinx.Graphics.Metal
             _currentState.Winding = frontFace.Convert();
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetFrontFace(renderCommandEncoder);
                 return;
             }
@@ -795,9 +788,8 @@ namespace Ryujinx.Graphics.Metal
             _currentState.BackRefValue = backRef;
 
             // Inline update
-            if (_pipeline.CurrentEncoderType == EncoderType.Render && _pipeline.CurrentEncoder != null)
+            if (_pipeline.Encoders.TryGetRenderEncoder(out MTLRenderCommandEncoder renderCommandEncoder))
             {
-                var renderCommandEncoder = new MTLRenderCommandEncoder(_pipeline.CurrentEncoder.Value);
                 SetStencilRefValue(renderCommandEncoder);
             }
 

--- a/src/Ryujinx.Graphics.Metal/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Metal/HelperShader.cs
@@ -277,7 +277,7 @@ namespace Ryujinx.Graphics.Metal
             DirtyFlags clearFlags = DirtyFlags.All & (~DirtyFlags.Scissors);
 
             // Save current state
-            EncoderState originalState = _pipeline.SwapState(_helperShaderState, clearFlags);
+            EncoderState originalState = _pipeline.SwapState(_helperShaderState, clearFlags, false);
 
             // Inherit some state without fully recreating render pipeline.
             RenderTargetCopy save = _helperShaderState.InheritForClear(originalState, false, index);
@@ -312,7 +312,7 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.Draw(4, 1, 0, 0);
 
             // Restore previous state
-            _pipeline.SwapState(null, clearFlags);
+            _pipeline.SwapState(null, clearFlags, false);
 
             _helperShaderState.Restore(save);
         }
@@ -330,7 +330,7 @@ namespace Ryujinx.Graphics.Metal
             var helperScissors = _helperShaderState.Scissors;
 
             // Save current state
-            EncoderState originalState = _pipeline.SwapState(_helperShaderState, clearFlags);
+            EncoderState originalState = _pipeline.SwapState(_helperShaderState, clearFlags, false);
 
             // Inherit some state without fully recreating render pipeline.
             RenderTargetCopy save = _helperShaderState.InheritForClear(originalState, true);
@@ -365,7 +365,7 @@ namespace Ryujinx.Graphics.Metal
             _pipeline.SetStencilTest(CreateStencilTestDescriptor(false));
 
             // Restore previous state
-            _pipeline.SwapState(null, clearFlags);
+            _pipeline.SwapState(null, clearFlags, false);
 
             _helperShaderState.Restore(save);
         }

--- a/src/Ryujinx.Graphics.Metal/MetalRenderer.cs
+++ b/src/Ryujinx.Graphics.Metal/MetalRenderer.cs
@@ -67,7 +67,10 @@ namespace Ryujinx.Graphics.Metal
 
         public void BackgroundContextAction(Action action, bool alwaysBackground = false)
         {
-            Logger.Warning?.Print(LogClass.Gpu, "Not Implemented!");
+            // GetData methods should be thread safe, so we can call this directly.
+            // Texture copy (scaled) may also happen in here, so that should also be thread safe.
+
+            action();
         }
 
         public BufferHandle CreateBuffer(int size, BufferAccess access)

--- a/src/Ryujinx.Graphics.Metal/MetalRenderer.cs
+++ b/src/Ryujinx.Graphics.Metal/MetalRenderer.cs
@@ -221,7 +221,7 @@ namespace Ryujinx.Graphics.Metal
 
         public void SetBufferData(BufferHandle buffer, int offset, ReadOnlySpan<byte> data)
         {
-            BufferManager.SetData(buffer, offset, data, _pipeline.Cbs, _pipeline.EndRenderPassDelegate);
+            BufferManager.SetData(buffer, offset, data, _pipeline.Cbs);
         }
 
         public void UpdateCounters()

--- a/src/Ryujinx.Graphics.Metal/PersistentFlushBuffer.cs
+++ b/src/Ryujinx.Graphics.Metal/PersistentFlushBuffer.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Graphics.GAL;
 using System;
 using System.Runtime.Versioning;
 
@@ -55,6 +56,40 @@ namespace Ryujinx.Graphics.Metal
 
             flushStorage.WaitForFences();
             srcBuffer?.DecrementReferenceCount();
+            return flushStorage.GetDataStorage(0, size);
+        }
+
+        public Span<byte> GetTextureData(CommandBufferPool cbp, Texture view, int size)
+        {
+            TextureCreateInfo info = view.Info;
+
+            var flushStorage = ResizeIfNeeded(size);
+
+            using (var cbs = cbp.Rent())
+            {
+                var buffer = flushStorage.GetBuffer().Get(cbs).Value;
+                var image = view.GetHandle();
+
+                view.CopyFromOrToBuffer(cbs, buffer, image, size, true, 0, 0, info.GetLayers(), info.Levels, singleSlice: false);
+            }
+
+            flushStorage.WaitForFences();
+            return flushStorage.GetDataStorage(0, size);
+        }
+
+        public Span<byte> GetTextureData(CommandBufferPool cbp, Texture view, int size, int layer, int level)
+        {
+            var flushStorage = ResizeIfNeeded(size);
+
+            using (var cbs = cbp.Rent())
+            {
+                var buffer = flushStorage.GetBuffer().Get(cbs).Value;
+                var image = view.GetHandle();
+
+                view.CopyFromOrToBuffer(cbs, buffer, image, size, true, layer, level, 1, 1, singleSlice: true);
+            }
+
+            flushStorage.WaitForFences();
             return flushStorage.GetDataStorage(0, size);
         }
 

--- a/src/Ryujinx.Graphics.Metal/PersistentFlushBuffer.cs
+++ b/src/Ryujinx.Graphics.Metal/PersistentFlushBuffer.cs
@@ -44,7 +44,7 @@ namespace Ryujinx.Graphics.Metal
 
                 if (srcBuffer.TryIncrementReferenceCount())
                 {
-                    BufferHolder.Copy(_pipeline, cbs, srcBuffer, dstBuffer, offset, 0, size, registerSrcUsage: false);
+                    BufferHolder.Copy(cbs, srcBuffer, dstBuffer, offset, 0, size, registerSrcUsage: false);
                 }
                 else
                 {

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.Graphics.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    class Pipeline : IPipeline, IDisposable
+    class Pipeline : IPipeline, IEncoderFactory, IDisposable
     {
         private const ulong MinByteWeightForFlush = 256 * 1024 * 1024; // MiB
 
@@ -27,7 +27,6 @@ namespace Ryujinx.Graphics.Metal
         private EncoderStateManager _encoderStateManager;
         private ulong _byteWeight;
 
-        public readonly Action EndRenderPassDelegate;
         public MTLCommandBuffer CommandBuffer;
 
         public IndexBufferPattern QuadsToTrisPattern;
@@ -35,8 +34,8 @@ namespace Ryujinx.Graphics.Metal
 
         internal CommandBufferScoped? PreloadCbs { get; private set; }
         internal CommandBufferScoped Cbs { get; private set; }
-        internal MTLCommandEncoder? CurrentEncoder { get; private set; }
-        internal EncoderType CurrentEncoderType { get; private set; } = EncoderType.None;
+        internal CommandBufferEncoder Encoders => Cbs.Encoders;
+        internal EncoderType CurrentEncoderType => Encoders.CurrentEncoderType;
         internal bool RenderPassActive { get; private set; }
 
         public Pipeline(MTLDevice device, MetalRenderer renderer)
@@ -44,7 +43,7 @@ namespace Ryujinx.Graphics.Metal
             _device = device;
             _renderer = renderer;
 
-            EndRenderPassDelegate = EndCurrentPass;
+            renderer.CommandBufferPool.Initialize(this);
 
             CommandBuffer = (Cbs = _renderer.CommandBufferPool.Rent()).CommandBuffer;
         }
@@ -79,15 +78,7 @@ namespace Ryujinx.Graphics.Metal
 
         public MTLRenderCommandEncoder GetOrCreateRenderEncoder(bool forDraw = false)
         {
-            MTLRenderCommandEncoder renderCommandEncoder;
-            if (CurrentEncoder == null || CurrentEncoderType != EncoderType.Render)
-            {
-                renderCommandEncoder = BeginRenderPass();
-            }
-            else
-            {
-                renderCommandEncoder = new MTLRenderCommandEncoder(CurrentEncoder.Value);
-            }
+            MTLRenderCommandEncoder renderCommandEncoder = Cbs.Encoders.EnsureRenderEncoder();
 
             if (forDraw)
             {
@@ -99,28 +90,12 @@ namespace Ryujinx.Graphics.Metal
 
         public MTLBlitCommandEncoder GetOrCreateBlitEncoder()
         {
-            if (CurrentEncoder != null)
-            {
-                if (CurrentEncoderType == EncoderType.Blit)
-                {
-                    return new MTLBlitCommandEncoder(CurrentEncoder.Value);
-                }
-            }
-
-            return BeginBlitPass();
+            return Cbs.Encoders.EnsureBlitEncoder();
         }
 
         public MTLComputeCommandEncoder GetOrCreateComputeEncoder(bool forDispatch = false)
         {
-            MTLComputeCommandEncoder computeCommandEncoder;
-            if (CurrentEncoder == null || CurrentEncoderType != EncoderType.Compute)
-            {
-                computeCommandEncoder = BeginComputePass();
-            }
-            else
-            {
-                computeCommandEncoder = new MTLComputeCommandEncoder(CurrentEncoder.Value);
-            }
+            MTLComputeCommandEncoder computeCommandEncoder = Cbs.Encoders.EnsureComputeEncoder();
 
             if (forDispatch)
             {
@@ -132,65 +107,17 @@ namespace Ryujinx.Graphics.Metal
 
         public void EndCurrentPass()
         {
-            if (CurrentEncoder != null)
-            {
-                switch (CurrentEncoderType)
-                {
-                    case EncoderType.Blit:
-                        new MTLBlitCommandEncoder(CurrentEncoder.Value).EndEncoding();
-                        CurrentEncoder = null;
-                        break;
-                    case EncoderType.Compute:
-                        new MTLComputeCommandEncoder(CurrentEncoder.Value).EndEncoding();
-                        CurrentEncoder = null;
-                        break;
-                    case EncoderType.Render:
-                        new MTLRenderCommandEncoder(CurrentEncoder.Value).EndEncoding();
-                        CurrentEncoder = null;
-                        RenderPassActive = false;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                CurrentEncoderType = EncoderType.None;
-            }
+            Cbs.Encoders.EndCurrentPass();
         }
 
-        private MTLRenderCommandEncoder BeginRenderPass()
+        public MTLRenderCommandEncoder CreateRenderCommandEncoder()
         {
-            EndCurrentPass();
-
-            var renderCommandEncoder = _encoderStateManager.CreateRenderCommandEncoder();
-
-            CurrentEncoder = renderCommandEncoder;
-            CurrentEncoderType = EncoderType.Render;
-            RenderPassActive = true;
-
-            return renderCommandEncoder;
+            return _encoderStateManager.CreateRenderCommandEncoder();
         }
 
-        private MTLBlitCommandEncoder BeginBlitPass()
+        public MTLComputeCommandEncoder CreateComputeCommandEncoder()
         {
-            EndCurrentPass();
-
-            var descriptor = new MTLBlitPassDescriptor();
-            var blitCommandEncoder = Cbs.CommandBuffer.BlitCommandEncoder(descriptor);
-
-            CurrentEncoder = blitCommandEncoder;
-            CurrentEncoderType = EncoderType.Blit;
-            return blitCommandEncoder;
-        }
-
-        private MTLComputeCommandEncoder BeginComputePass()
-        {
-            EndCurrentPass();
-
-            var computeCommandEncoder = _encoderStateManager.CreateComputeCommandEncoder();
-
-            CurrentEncoder = computeCommandEncoder;
-            CurrentEncoderType = EncoderType.Compute;
-            return computeCommandEncoder;
+            return _encoderStateManager.CreateComputeCommandEncoder();
         }
 
         public void Present(CAMetalDrawable drawable, Texture src, Extents2D srcRegion, Extents2D dstRegion, bool isLinear)
@@ -279,19 +206,15 @@ namespace Ryujinx.Graphics.Metal
             {
                 case EncoderType.Render:
                     {
-                        var renderCommandEncoder = GetOrCreateRenderEncoder();
-
                         var scope = MTLBarrierScope.Buffers | MTLBarrierScope.Textures | MTLBarrierScope.RenderTargets;
                         MTLRenderStages stages = MTLRenderStages.RenderStageVertex | MTLRenderStages.RenderStageFragment;
-                        renderCommandEncoder.MemoryBarrier(scope, stages, stages);
+                        Encoders.RenderEncoder.MemoryBarrier(scope, stages, stages);
                         break;
                     }
                 case EncoderType.Compute:
                     {
-                        var computeCommandEncoder = GetOrCreateComputeEncoder();
-
                         var scope = MTLBarrierScope.Buffers | MTLBarrierScope.Textures | MTLBarrierScope.RenderTargets;;
-                        computeCommandEncoder.MemoryBarrier(scope);
+                        Encoders.ComputeEncoder.MemoryBarrier(scope);
                         break;
                     }
             }
@@ -353,7 +276,7 @@ namespace Ryujinx.Graphics.Metal
             var srcBuffer = _renderer.BufferManager.GetBuffer(src, srcOffset, size, false);
             var dstBuffer = _renderer.BufferManager.GetBuffer(dst, dstOffset, size, true);
 
-            BufferHolder.Copy(this, Cbs, srcBuffer, dstBuffer, srcOffset, dstOffset, size);
+            BufferHolder.Copy(Cbs, srcBuffer, dstBuffer, srcOffset, dstOffset, size);
         }
 
         public void DispatchCompute(int groupsX, int groupsY, int groupsZ)
@@ -712,9 +635,7 @@ namespace Ryujinx.Graphics.Metal
         {
             if (CurrentEncoderType == EncoderType.Render)
             {
-                var renderCommandEncoder = GetOrCreateRenderEncoder();
-
-                renderCommandEncoder.MemoryBarrier(MTLBarrierScope.Textures, MTLRenderStages.RenderStageFragment, MTLRenderStages.RenderStageFragment);
+                Encoders.RenderEncoder.MemoryBarrier(MTLBarrierScope.Textures, MTLRenderStages.RenderStageFragment, MTLRenderStages.RenderStageFragment);
             }
         }
 

--- a/src/Ryujinx.Graphics.Metal/Pipeline.cs
+++ b/src/Ryujinx.Graphics.Metal/Pipeline.cs
@@ -56,8 +56,13 @@ namespace Ryujinx.Graphics.Metal
             TriFanToTrisPattern = new IndexBufferPattern(_renderer, 3, 3, 2, [int.MinValue, -1, 0], 1, true);
         }
 
-        public EncoderState SwapState(EncoderState state, DirtyFlags flags = DirtyFlags.All)
+        public EncoderState SwapState(EncoderState state, DirtyFlags flags = DirtyFlags.All, bool endRenderPass = true)
         {
+            if (endRenderPass && CurrentEncoderType == EncoderType.Render)
+            {
+                EndCurrentPass();
+            }
+
             return _encoderStateManager.SwapState(state, flags);
         }
 


### PR DESCRIPTION
- Tie current encoder to command buffer. This allows extra command buffers to mainain their own encoder state without interrupting the main encoder.
  - This fixes an issue where buffer data preload would randomly split the render pass in the main thread.
- Support background context actions, specifically Texture GetData and SetData methods.
  - Implemented CopyFromOrToBuffer for textures. Should probably use it for other methods to avoid duplication, but it could be error prone so I put it off for now.
- Fix an issue where helper shaders that used render targets weren't ending their render pass when returning to the main state. Some helpers (clear color/depth) can skip doing this.

- Doesn't currently support scaled copy from background thread (it's skipped). Required for resolution scale.