### PR TITLE
Patch some leaks and only perform copies on valid textures

### DIFF
--- a/src/Ryujinx.Graphics.Metal/CommandBufferEncoder.cs
+++ b/src/Ryujinx.Graphics.Metal/CommandBufferEncoder.cs
@@ -149,7 +149,7 @@ class CommandBufferEncoder
     {
         EndCurrentPass();
 
-        var descriptor = new MTLBlitPassDescriptor();
+        using var descriptor = new MTLBlitPassDescriptor();
         var blitCommandEncoder = _commandBuffer.BlitCommandEncoder(descriptor);
 
         CurrentEncoder = blitCommandEncoder;

--- a/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
+++ b/src/Ryujinx.Graphics.Metal/EncoderStateManager.cs
@@ -176,14 +176,11 @@ namespace Ryujinx.Graphics.Metal
 
         public readonly MTLComputeCommandEncoder CreateComputeCommandEncoder()
         {
-            var descriptor = new MTLComputePassDescriptor();
+            using var descriptor = new MTLComputePassDescriptor();
             var computeCommandEncoder = _pipeline.CommandBuffer.ComputeCommandEncoder(descriptor);
 
             // Mark all state as dirty to ensure it is set on the encoder
             SignalDirty(DirtyFlags.ComputeAll);
-
-            // Cleanup
-            descriptor.Dispose();
 
             return computeCommandEncoder;
         }

--- a/src/Ryujinx.Graphics.Metal/Program.cs
+++ b/src/Ryujinx.Graphics.Metal/Program.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.Metal
             {
                 ShaderSource shader = _shaders[i];
 
-                var compileOptions = new MTLCompileOptions
+                using var compileOptions = new MTLCompileOptions
                 {
                     PreserveInvariance = true,
                     LanguageVersion = MTLLanguageVersion.Version31,

--- a/src/Ryujinx.Graphics.Metal/Sampler.cs
+++ b/src/Ryujinx.Graphics.Metal/Sampler.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Graphics.Metal
 
             MTLSamplerBorderColor borderColor = GetConstrainedBorderColor(info.BorderColor, out _);
 
-            var samplerState = device.NewSamplerState(new MTLSamplerDescriptor
+            using var descriptor = new MTLSamplerDescriptor
             {
                 BorderColor = borderColor,
                 MinFilter = minFilter,
@@ -31,7 +31,9 @@ namespace Ryujinx.Graphics.Metal
                 TAddressMode = info.AddressV.Convert(),
                 RAddressMode = info.AddressP.Convert(),
                 SupportArgumentBuffers = true
-            });
+            };
+
+            var samplerState = device.NewSamplerState(descriptor);
 
             _mtlSamplerState = samplerState;
         }

--- a/src/Ryujinx.Graphics.Metal/Texture.cs
+++ b/src/Ryujinx.Graphics.Metal/Texture.cs
@@ -151,6 +151,11 @@ namespace Ryujinx.Graphics.Metal
             TextureBase src = this;
             TextureBase dst = (TextureBase)destination;
 
+            if (!Valid || !dst.Valid)
+            {
+                return;
+            }
+
             var srcImage = GetHandle();
             var dstImage = dst.GetHandle();
 
@@ -202,6 +207,11 @@ namespace Ryujinx.Graphics.Metal
 
             TextureBase src = this;
             TextureBase dst = (TextureBase)destination;
+
+            if (!Valid || !dst.Valid)
+            {
+                return;
+            }
 
             var srcImage = GetHandle();
             var dstImage = dst.GetHandle();


### PR DESCRIPTION
Fixes some random crashes in MK8D relating to invalid texture copies. Prevents some resources from leaking.

I made these changes a while ago and forgot to push them.